### PR TITLE
adds user model and placeholder auth endpoint

### DIFF
--- a/priv/repo/migrations/20170220201218_create_user.exs
+++ b/priv/repo/migrations/20170220201218_create_user.exs
@@ -1,0 +1,14 @@
+defmodule Adpq.Repo.Migrations.CreateUser do
+  use Ecto.Migration
+
+  def change do
+    create table(:users) do
+      add :name, :string, unique: true
+      add :password, :string
+      add :role, :string
+
+      timestamps()
+    end
+
+  end
+end

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -54,4 +54,14 @@ defmodule Adpq.CatalogSeeds do
   end
 end
 
+defmodule Adpq.UserSeeds do
+  alias Adpq.Repo
+  alias Adpq.User
+
+  def create_admin do
+    Repo.insert!(User.changeset(%User{}, %{name: "admin", password: "admin", role: "ADMIN"}))
+  end
+end
+
 Adpq.CatalogSeeds.insertRows()
+Adpq.UserSeeds.create_admin()

--- a/test/controllers/auth_controller_test.exs
+++ b/test/controllers/auth_controller_test.exs
@@ -1,0 +1,49 @@
+defmodule Adpq.AuthControllerTest do
+  use Adpq.ConnCase
+
+  alias Adpq.{User}
+
+  @user1 %{"name" => "user1", "password" => "user"}
+  @user2 %{"name" => "user2", "password" => "user"}
+  @invalid_user %{"name" => "user3", "password" => "wrong"}
+  @admin %{"name" => "admin", "password" => "admin"}
+  @invalid_admin %{"name" => "admin", "password" => "wrong"}
+
+  setup %{conn: conn} do
+    { :ok, conn: put_req_header(conn, "accept", "application/json") }
+    %{
+      user: User.find_or_create_by_name(Map.put(@user1, "role", "USER")),
+      admin: User.find_or_create_by_name(Map.put(@admin, "role", "ADMIN"))
+    }
+  end
+
+  test "returns success for existing user", %{user: user} do
+    conn = build_conn()
+    conn = post conn, auth_path(conn, :create, @user1)
+    assert json_response(conn, 200)["id"] == user.id
+  end
+
+  test "returns success for new user" do
+    conn = build_conn()
+    conn = post conn, auth_path(conn, :create, @user2)
+    assert json_response(conn, 200)["name"] == @user2["name"]
+  end
+
+  test "returns unauthorized for incorrect user password" do
+    conn = build_conn()
+    conn = post conn, auth_path(conn, :create, @invalid_user)
+    assert conn.status == 401
+  end
+
+  test "returns success for existing admin", %{admin: admin} do
+    conn = build_conn()
+    conn = post conn, auth_path(conn, :create, @admin)
+    assert json_response(conn, 200)["id"] == admin.id
+  end
+
+  test "returns success for incorrect admin password" do
+    conn = build_conn()
+    conn = post conn, auth_path(conn, :create, @invalid_admin)
+    assert conn.status == 401
+  end
+end

--- a/test/models/user_test.exs
+++ b/test/models/user_test.exs
@@ -1,0 +1,32 @@
+defmodule Adpq.UserTest do
+  use Adpq.ModelCase
+
+  alias Adpq.{User, Repo}
+
+  @valid_attrs %{name: "name", password: "pw", role: "USER"}
+  @invalid_attrs %{}
+
+  test "changeset with valid attributes" do
+    changeset = User.changeset(%User{}, @valid_attrs)
+    assert changeset.valid?
+  end
+
+  test "changeset with invalid attributes" do
+    changeset = User.changeset(%User{}, @invalid_attrs)
+    refute changeset.valid?
+  end
+
+  test "find or create a new user (user already exists)" do
+    user = Repo.insert!(User.changeset(%User{}, @valid_attrs))
+    params =
+      for {key, val} <- @valid_attrs, into: %{}, do: {Atom.to_string(key), val}
+    found_or_created = User.find_or_create_by_name(params)
+    assert user.id === found_or_created.id
+  end
+
+  test "find or create new user" do
+    attributes = %{name: "test", password: "test", role: "USER"}
+    user = Repo.insert!(User.changeset(%User{}, attributes))
+    assert user.id !== nil
+  end
+end

--- a/web/controllers/auth_controller.ex
+++ b/web/controllers/auth_controller.ex
@@ -1,0 +1,20 @@
+defmodule Adpq.AuthController do
+  use Adpq.Web, :controller
+
+  alias Adpq.{User, Repo}
+
+  def create(conn, %{"name" => username, "password" => "user"} = params) do
+    user = User.find_or_create_by_name(Map.put(params, "role", "USER"))
+    render(conn, "show.json", auth: user)
+  end
+
+  def create(conn, %{"name" => "admin", "password" => "admin"}) do
+    user = Repo.get_by!(User, name: "admin")
+    render(conn, "show.json", auth: user)
+  end
+
+  def create(conn, _) do
+    send_resp(conn, :unauthorized, "")
+  end
+
+end

--- a/web/models/user.ex
+++ b/web/models/user.ex
@@ -1,0 +1,33 @@
+defmodule Adpq.User do
+  use Adpq.Web, :model
+
+  alias Adpq.Repo
+
+  schema "users" do
+    field :name, :string
+    field :password, :string
+    field :role, :string
+
+    timestamps()
+  end
+
+  @doc """
+  Builds a changeset based on the `struct` and `params`.
+  """
+  def changeset(struct, params \\ %{}) do
+    struct
+    |> cast(params, [:name, :password, :role])
+    |> validate_required([:name, :password, :role])
+  end
+
+  def find_or_create_by_name(%{"name" => name, "password" => password, "role" => role} = params) do
+    exists =
+      Adpq.User
+      |> where(name: ^name)
+      |> Repo.one
+    case exists do
+      %Adpq.User{} -> exists
+      _ -> Repo.insert!(Adpq.User.changeset(%Adpq.User{}, params))
+    end
+  end
+end

--- a/web/router.ex
+++ b/web/router.ex
@@ -18,8 +18,9 @@ defmodule Adpq.Router do
   scope "/api", Adpq do
     pipe_through :api
     resources "/catalog_items", CatalogItemController, except: [:new, :edit]
+    resources "/auth", AuthController, only: [:create]
   end
-  
+
   scope "/", Adpq do
     pipe_through :browser # Use the default browser stack
 

--- a/web/views/auth_view.ex
+++ b/web/views/auth_view.ex
@@ -1,0 +1,18 @@
+defmodule Adpq.AuthView do
+  use Adpq.Web, :view
+
+  alias Adpq.User
+
+  def render("show.json", %{auth: user}) do
+    render_one(user, Adpq.AuthView, "auth.json")
+  end
+
+  def render("auth.json", %{auth: user}) do
+    %{
+      id: user.id,
+      name: user.name,
+      role: user.role
+    }
+  end
+
+end


### PR DESCRIPTION
It works as follows:
  - There will be a pre-seeded `admin/admin` user
  - Any attempt to login w/ the password `user` will succeed, creating a new user record if necessary. This is so demo users can have individual carts

It just returns the user id, name and role, rather than i.e. a signed token
